### PR TITLE
Restyle the search bar

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -20,4 +20,12 @@
   > .container {
     justify-content: space-around;  // center the search box
   }
+
+  .search_field {
+    flex: none;
+  }
+
+  auto-complete {
+    flex: auto;
+  }
 }

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -13,6 +13,11 @@
 .al-masthead + .navbar-search {
   border: 0; // overriding the style from arclight
 }
+
 .navbar-search {
   padding-bottom: 1rem;
+
+  > .container {
+    justify-content: space-around;  // center the search box
+  }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -63,7 +63,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     config.index.constraints_component = Arclight::ConstraintsComponent
     config.index.document_presenter_class = Arclight::IndexPresenter
     config.add_results_document_tool :arclight_bookmark_control, partial: 'arclight_bookmark_control'
-    config.index.search_bar_component = Arclight::SearchBarComponent
+    config.index.search_bar_component = Blacklight::SearchBarComponent
     config.index.document_actions.delete(:bookmark)
     # config.index.thumbnail_field = 'thumbnail_path_ss'
 


### PR DESCRIPTION
- Use blacklight's search bar to remove the collection dropdown
- Center the search bar in the navigation

closes #79 