### PR TITLE
Hide back to search and start over button on show pages

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -7,6 +7,13 @@
 @import 'arclight/app/assets/stylesheets/arclight/application';
 @import 'sulFooter';
 
+
+.blacklight-catalog-show {
+  .constraints-container {
+    display: none; // Never show "back to search" or "start over" on an item show page.
+  }
+}
+
 .al-masthead, .navbar-search {
   background-color: $stanford-fog-light;
 }


### PR DESCRIPTION
These only display when you have an active search session, but we never want to display them. This follows the solution found by exhibits: https://github.com/sul-dlss/exhibits/blob/b52e00e744dec65e7e290a8987886bd52be01a54/app/assets/stylesheets/modules/blacklight_overrides.scss\#L35-L37

Fixes #84