### PR TITLE
Set the page title as requested

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,6 +1,6 @@
 en:
   blacklight:
-    application_name: 'Stanford | Libraries'
+    application_name: 'Taube Archive of the International Military Tribunal (IMT) at Nuremberg (1945-1946)'
     search:
       facets:
         title: Find items by…


### PR DESCRIPTION
Fixes #102

NOTE: the application title is cached by blacklight, so if you change it you must clear the cache.