### PR TITLE
Do not display access section for the components

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/arclight.git
-  revision: 29d268a0e04d3560984c22f7f2cef6eb0767df7d
+  revision: 156e44d1b50c5f28e7c889ff155a03a3ce56e3f6
   specs:
     arclight (1.0.0.alpha)
       blacklight (>= 7.14, < 9)
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: https://github.com/projectblacklight/blacklight.git
-  revision: 66708bbb8aee981cbcbab4d6540614b97820547c
+  revision: f30340e7cdbb2b166488ffa7f9bc6f628a25a131
   branch: main
   specs:
     blacklight (8.0.0.alpha)
@@ -421,7 +421,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yell (2.2.2)
-    zeitwerk (2.6.3)
+    zeitwerk (2.6.4)
 
 PLATFORMS
   x86_64-darwin-20

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,6 +71,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     config.show.document_component = Arclight::DocumentComponent
     config.show.breadcrumb_component = BreadcrumbHierarchyComponent
     config.show.embed_component = Arclight::EmbedComponent
+    config.show.access_component = Arclight::AccessComponent
     config.show.display_type_field = 'level_ssm'
     # config.show.thumbnail_field = 'thumbnail_path_ss'
     config.show.document_presenter_class = Arclight::ShowPresenter
@@ -82,6 +83,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
       indexed_terms_field
     ]
 
+    # The access section for a collection
     config.show.context_access_tab_items = %i[
       terms_field
       cite_field
@@ -94,12 +96,9 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
       component_indexed_terms_field
     ]
 
-    config.show.component_access_tab_items = %i[
-      component_terms_field
-      cite_field
-      in_person_field
-      contact_field
-    ]
+    # Do not display access section for components because
+    # all NTA components have the same access status as the collection as a whole.
+    config.show.component_access_tab_items = []
 
     ##
     # Collection Context


### PR DESCRIPTION
because all NTA components have the same access status as the collection as a whole.
Fixes #124