### PR TITLE
Adds :hierarchy and :nest_path to search_state_fields configuration

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -239,7 +239,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     end
 
     # These are the parameters passed through in search_state.params_for_search
-    config.search_state_fields += %i[id group hierarchy_context original_document]
+    config.search_state_fields += %i[group hierarchy hierarchy_context id nest_path original_document]
     config.search_state_fields << { original_parents: [] }
 
     # "sort results by" select (pulldown)


### PR DESCRIPTION
Resolves errors such as:

```
Unpermitted parameters: :hierarchy, :nest_path. Context: { controller: CatalogController, action: hierarchy, request: #<ActionDispatch::Request:0x000000011497de10>, params: {"hierarchy"=>"true", "nest_path"=>"/components#5/components#0/components#3", "controller"=>"catalog", "action"=>"hierarchy", "id"=>"mt839rq8746"} }
```