### PR TITLE
Virtual Tribunals name changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
   agent any
 
   environment {
-    PROJECT = 'sul-dlss/nta-arclight'
+    PROJECT = 'sul-dlss/vt-arclight'
   }
 
   stages {
@@ -23,7 +23,7 @@ pipeline {
           export DEPLOY=1
 
           # Load RVM
-          rvm use 3.1.2@nta-arclight --create
+          rvm use 3.1.2@vt-arclight --create
           gem install bundler
 
           bundle install --without production
@@ -68,7 +68,7 @@ pipeline {
           export REVISION=$TAG_NAME
 
           # Load RVM
-          rvm use 3.1.2@nta-arclight --create
+          rvm use 3.1.2@vt-arclight --create
           gem install bundler
 
           bundle install --without production

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Nurembeg Trial Archive
+# Virtual Tribunals
 
-An Arclight-based discovery application for materials from the Nuremberg Trial
+An Arclight-based discovery application for materials from the Virtual Tribunals project
 
 ## Install
 ```
@@ -15,7 +15,7 @@ First start solr.
 bundle exec solr_wrapper
 ```
 
-## Index data from NTA records stored in ArchivesSpace
+## Index data from records stored in ArchivesSpace
 
 ### Required environment variables
 Making requests to the ArchivesSpace endpoints via rake task requires that certain environment variables are set. Locally you can pass them on the command line or set them up another way. On staging and production servers, they are stored and accessible.
@@ -25,28 +25,28 @@ Making requests to the ArchivesSpace endpoints via rake task requires that certa
 
 You can get the values of Vault by running the following (stage example):
 ```shell
-vault kv get puppet/application/nta/stage/aspace_url
-vault kv get puppet/application/nta/stage/aspace_user
-vault kv get puppet/application/nta/stage/aspace_password
+vault kv get puppet/application/vt/stage/aspace_url
+vault kv get puppet/application/vt/stage/aspace_user
+vault kv get puppet/application/vt/stage/aspace_password
 ```
 
 ### Requesting data and indexing it
-1. Find out the ID of the Resource and its Resository that you want in ArchivesSpace. Repository refers to internal SUL organization. For now we assume the Reposiotry ID is `2`, for Special Collections. This is subject to change in development. 
+1. Find out the ID of the Resource and its Resository that you want in ArchivesSpace. Repository refers to internal SUL organization. For now we assume the Repository ID is `2`, for Special Collections. This is subject to change in development. 
 
-    "Resource" is the name for top level containers in ArchivesSpace. The Resource ID is the permanent identifier we use for the NTA collection. It's the same as the PURL and won't change: `mt839rq8746`
+    "Resource" is the name for top level containers in ArchivesSpace. The Resource ID is the permanent identifier we use for the collection. It's the same as the PURL and won't change: `mt839rq8746`
 
-2. Download the NTA EAD for a specific Resource. This will download EAD to our `/data` folder with the Resource ID as the filename, e.g. `/data/mt839rq8746.xml`. You can use the following command. When trying to pass arguments to a rake task in the form of `[arg1,arg2]`, it seems my zsh shell requires escaping the brackets:
+2. Download the EAD for a specific Resource. This will download EAD to our `/data` folder with the Resource ID as the filename, e.g. `/data/mt839rq8746.xml`. You can use the following command. When trying to pass arguments to a rake task in the form of `[arg1,arg2]`, it seems my zsh shell requires escaping the brackets:
     ```shell
-    rake nta:download_resource\[2,mt839rq8746\]           
+    rake vt:download_resource\[2,mt839rq8746\]           
     ```
 
     Locally with passing env variables, the command could like like this:
     ```shell
-     ASPACE_URL=http://spec-as-stage.stanford.edu:8089 ASPACE_USER=<xxx> ASPACE_PASSWORD=<xxx> rake nta:download_resource\[2,mt839rq8746\]  
+     ASPACE_URL=http://spec-as-stage.stanford.edu:8089 ASPACE_USER=<xxx> ASPACE_PASSWORD=<xxx> rake vt:download_resource\[2,mt839rq8746\]  
      ```
 3. Index the file.
     ```shell
-     rake nta:index 
+     rake vt:index 
     ```
 ## Start the app
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>NtaArclight</title>
+    <title>Virtual Tribunals</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module NtaArclight
+module VtArclight
   # Holds configuration for the application
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-set :application, "nta-arclight"
-set :repo_url, "https://github.com/sul-dlss/nta-arclight.git"
+set :application, "vt-arclight"
+set :repo_url, "https://github.com/sul-dlss/vt-arclight.git"
 
 # Default branch is :master so we need to update to main
 if ENV['DEPLOY']
@@ -11,7 +11,7 @@ else
 end
 
 # Default deploy_to directory is /var/www/application-name
-set :deploy_to, "/opt/app/nta/nta"
+set :deploy_to, "/opt/app/vt/vt"
 
 # Default value for :linked_files is []
 set :linked_files, %w[config/database.yml config/blacklight.yml]

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-server 'nta-prod-a.stanford.edu', user: 'nta', roles: %w[web db app]
-server 'nta-prod-b.stanford.edu', user: 'nta', roles: %w[web app]
+server 'vt-prod-a.stanford.edu', user: 'vt', roles: %w[web db app]
+server 'vt-prod-b.stanford.edu', user: 'vt', roles: %w[web app]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-server 'nta-stage-a.stanford.edu', user: 'nta', roles: %w[web db app]
-server 'nta-stage-b.stanford.edu', user: 'nta', roles: %w[web app]
+server 'vt-stage-a.stanford.edu', user: 'vt', roles: %w[web db app]
+server 'vt-stage-b.stanford.edu', user: 'vt', roles: %w[web app]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     environment:
       NODE_ENV: development
       RAILS_LOG_TO_STDOUT: 'true'
-      # SOLR_URL: http://solr:8983/solr/nta-arclight
       # Docker doesn't allow rails server to remove PID on shutdown
       PID_FILE: /dev/null
     depends_on:

--- a/lib/tasks/vt.rake
+++ b/lib/tasks/vt.rake
@@ -2,7 +2,7 @@
 
 require 'fileutils'
 
-namespace :nta do
+namespace :vt do
   # "Resource" is the name for top level containers in ArchivesSpace
   desc 'Download EAD for a Resource in ArchivesSpace to the /data directory'
   task :download_resource, %i[repository_id resource_id] => :environment do |_task, args|


### PR DESCRIPTION
- Change rake task namespace to 'vt'
- Change capistrano configs to use 'vt' naming
- Rename application module to VtArclight
- Set the application HTML title to 'Virtual Tribunals'
- Update CD config to use 'vt' name
- Remove solr references from docker-compose.yml
- Update README for name change to Virtual Tribunals

In addition to this, we need to:
- [ ] change the git repository name to vt-arclight
- [ ] change the shared_configs branch names to vt-*
- [ ] ???
- [ ] profit
